### PR TITLE
Refactor + crash fix for Older SDK 23 failing to bind + iOS binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ iOS:
 ```javascript
 import Wifi from "react-native-iot-wifi";
 
-Wifi.isAvailable((available) => {
+Wifi.isApiAvailable((available) => {
   console.log(available ? 'available' : 'failed');
 });
 

--- a/android/src/main/java/com/tadasr/IOTWifi/IOTWifiModule.java
+++ b/android/src/main/java/com/tadasr/IOTWifi/IOTWifiModule.java
@@ -36,7 +36,7 @@ public class IOTWifiModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void isAvailable(final Callback callback) {
+    public void isApiAvailable(final Callback callback) {
         callback.invoke(true);
     }
 

--- a/android/src/main/java/com/tadasr/IOTWifi/IOTWifiModule.java
+++ b/android/src/main/java/com/tadasr/IOTWifi/IOTWifiModule.java
@@ -88,7 +88,7 @@ public class IOTWifiModule extends ReactContextBaseJavaModule {
                     bindToNetwork(ssid, callback);
                 } catch (Exception e) {
                     callback.invoke();
-                    Log.d("Failed to bind to Wifi: ", ssid);
+                    Log.d("IoTWifi", "Failed to bind to Wifi: " + ssid);
                 }
             } else {
                 callback.invoke();
@@ -227,7 +227,7 @@ public class IOTWifiModule extends ReactContextBaseJavaModule {
         if (configList != null) {
             for (WifiConfiguration wifiConfig : configList) {
                 if (wifiConfig.SSID.equals(comparableSSID)) {
-                    Log.d("Found Matching Wifi: ", wifiConfig.toString());
+                    Log.d("IoTWifi", "Found Matching Wifi: "+ wifiConfig.toString());
                     existingNetworkId = wifiConfig.networkId;
                     break;
 

--- a/android/src/main/java/com/tadasr/IOTWifi/IOTWifiModule.java
+++ b/android/src/main/java/com/tadasr/IOTWifi/IOTWifiModule.java
@@ -57,7 +57,7 @@ public class IOTWifiModule extends ReactContextBaseJavaModule {
 
     private void connectToWifi(String ssid, String passphrase, Boolean isWEP, Boolean bindNetwork, Callback callback) {
         if (Build.VERSION.SDK_INT > 28) {
-            callback.invoke("Fail");
+            callback.invoke("Not supported on Android Q");
             return;
         }
         removeSSID(ssid);
@@ -70,7 +70,7 @@ public class IOTWifiModule extends ReactContextBaseJavaModule {
             wifiManager.disconnect();
             boolean success =  wifiManager.enableNetwork(networkId, true);
             if (!success) {
-                callback.invoke("Failed to add network configuration");
+                callback.invoke("Failed to enable added network");
                 return;
             }
             success = wifiManager.reconnect();
@@ -87,8 +87,8 @@ public class IOTWifiModule extends ReactContextBaseJavaModule {
                 try {
                     bindToNetwork(ssid, callback);
                 } catch (Exception e) {
-                    System.out.println(e.getMessage());
                     callback.invoke();
+                    Log.d("Failed to bind to Wifi: ", ssid);
                 }
             } else {
                 callback.invoke();
@@ -227,7 +227,7 @@ public class IOTWifiModule extends ReactContextBaseJavaModule {
         if (configList != null) {
             for (WifiConfiguration wifiConfig : configList) {
                 if (wifiConfig.SSID.equals(comparableSSID)) {
-                    Log.d("wifi", wifiConfig.toString());
+                    Log.d("Found Matching Wifi: ", wifiConfig.toString());
                     existingNetworkId = wifiConfig.networkId;
                     break;
 

--- a/example/App.js
+++ b/example/App.js
@@ -42,7 +42,7 @@ export default class App extends Component {
   }
 
   testWifi(){
-    Wifi.isAvailable((available) => {
+    Wifi.isApiAvailable((available) => {
       
       this.setState({isApiAvaliable: available});
       

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ declare module 'react-native-iot-wifi' {
     | [string, boolean, (error: string) => void];
 
   export namespace RNWifi {
-    function isAvailable(cb: (available: boolean) => void): void;
+    function isApiAvailable(cb: (available: boolean) => void): void;
     function getSSID(cb: (ssid: string) => void): void;
     function connect(...args: ConnectArgs): void;
     function connectSecure(...args: ConnectSecureArgs): void;

--- a/index.js
+++ b/index.js
@@ -55,5 +55,4 @@ module.exports = {
  * todo: connectSecure(String ssid, String passphrase, Boolean isWEP, Boolean bindNetwork = false, Callback callback)
  * removeSSID(String ssid, Boolean unbindNetwork = false, Callback callback)
  * getSSID(Callback callback)
- * Android only: forceWifiUsage()
  */

--- a/index.js
+++ b/index.js
@@ -36,21 +36,21 @@ function getSSID(...args) {
   NativeModules.IOTWifi.getSSID(...args);
 }
 
-function isAvailable(...args) {
-  NativeModules.IOTWifi.isAvailable(...args);
+function isApiAvailable(...args) {
+  NativeModules.IOTWifi.isApiAvailable(...args);
 }
 
 module.exports = {
   connect: connect,
   connectSecure: connectSecure,
   getSSID: getSSID,
-  isAvailable: isAvailable,
+  isApiAvailable: isApiAvailable,
   removeSSID: removeSSID,
 };
 
 /**
  * (un)bindNetwork only affects Android
- * isAvailable(Callback callback)
+ * isApiAvailable(Callback callback)
  * connect(String ssid, Boolean bindNetwork = false, Callback callback)
  * todo: connectSecure(String ssid, String passphrase, Boolean isWEP, Boolean bindNetwork = false, Callback callback)
  * removeSSID(String ssid, Boolean unbindNetwork = false, Callback callback)

--- a/ios/IOTWifi.m
+++ b/ios/IOTWifi.m
@@ -89,17 +89,5 @@
 
         callback(@[@"Cannot detect SSID"]);
     }
-    
-    RCT_EXPORT_METHOD(useWifiRequests:(BOOL)useRequests
-                      resolver:(RCTPromiseResolveBlock)resolve
-                      rejecter:(RCTPromiseRejectBlock)reject) {
-        resolve([NSNumber numberWithBool:false]);
-    }
-    
-    RCT_EXPORT_METHOD(request:(NSString*)urlString
-                      resolver:(RCTPromiseResolveBlock)resolve
-                      rejecter:(RCTPromiseRejectBlock)reject) {
-        reject(@"no_implementation", @"There are no implementation on iOS", [NSError errorWithDomain:@"com.iotwifi" code:-1 userInfo:nil]);
-    }
 @end
 

--- a/ios/IOTWifi.m
+++ b/ios/IOTWifi.m
@@ -14,7 +14,7 @@
     }
     
     RCT_EXPORT_METHOD(connect:(NSString*)ssid
-                      bindNetwork:(BOOL)bindNetwork
+                      bindNetwork:(BOOL)bindNetwork //Ignored
                       callback:(RCTResponseSenderBlock)callback) {
         if (@available(iOS 11.0, *)) {
             NEHotspotConfiguration* configuration = [[NEHotspotConfiguration alloc] initWithSSID:ssid];
@@ -32,14 +32,11 @@
             callback(@[@"Not supported in iOS<11.0"]);
         }
     }
-    
-    RCT_EXPORT_METHOD(forceWifiUsage:(BOOL)force) {
-    }
-    
+        
     RCT_EXPORT_METHOD(connectSecure:(NSString*)ssid
                       withPassphrase:(NSString*)passphrase
                       isWEP:(BOOL)isWEP
-                      bindNetwork:(BOOL)bindNetwork
+                      bindNetwork:(BOOL)bindNetwork //Ignored
                       callback:(RCTResponseSenderBlock)callback) {
         
         if (@available(iOS 11.0, *)) {
@@ -60,7 +57,7 @@
     }
     
     RCT_EXPORT_METHOD(removeSSID:(NSString*)ssid
-                      unbindNetwork:(BOOL)unbindNetwork
+                      unbindNetwork:(BOOL)unbindNetwork //Ignored
                       callback:(RCTResponseSenderBlock)callback) {
         
         if (@available(iOS 11.0, *)) {

--- a/ios/IOTWifi.m
+++ b/ios/IOTWifi.m
@@ -18,7 +18,7 @@
                       callback:(RCTResponseSenderBlock)callback) {
         if (@available(iOS 11.0, *)) {
             NEHotspotConfiguration* configuration = [[NEHotspotConfiguration alloc] initWithSSID:ssid];
-            configuration.joinOnce = true;
+            configuration.joinOnce = !bindNetwork;
             
             [[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration completionHandler:^(NSError * _Nullable error) {
                 if (error != nil) {
@@ -36,12 +36,12 @@
     RCT_EXPORT_METHOD(connectSecure:(NSString*)ssid
                       withPassphrase:(NSString*)passphrase
                       isWEP:(BOOL)isWEP
-                      bindNetwork:(BOOL)bindNetwork //Ignored
+                      bindNetwork:(BOOL)bindNetwork
                       callback:(RCTResponseSenderBlock)callback) {
         
         if (@available(iOS 11.0, *)) {
             NEHotspotConfiguration* configuration = [[NEHotspotConfiguration alloc] initWithSSID:ssid passphrase:passphrase isWEP:isWEP];
-            configuration.joinOnce = true;
+            configuration.joinOnce = !bindNetwork;
             
             [[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration completionHandler:^(NSError * _Nullable error) {
                 if (error != nil) {

--- a/ios/IOTWifi.m
+++ b/ios/IOTWifi.m
@@ -5,7 +5,7 @@
 
 @implementation IOTWifi
     RCT_EXPORT_MODULE();
-    RCT_EXPORT_METHOD(isAvailable:(RCTResponseSenderBlock)callback) {
+    RCT_EXPORT_METHOD(isApiAvailable:(RCTResponseSenderBlock)callback) {
         NSNumber *available = @NO;
         if (@available(iOS 11.0, *)) {
             available = @YES;


### PR DESCRIPTION
This PR is updating 
- Change isAvailable to isApiAvailable
- Ignores binding crashes on SDK 23 (still haven't figure out why its crashing)
- Fixes the iOS react exports to match the index.js and fixes the crash
- Fix: detecting pre-added system config which can't be enabled or removed

Crash Report for SDK 23 binding call
```
java.lang.SecurityException: com.hudl.focus was not granted  either of these permissions: android.permission.CHANGE_NETWORK_STATE, android.permission.WRITE_SETTINGS.
```